### PR TITLE
Add MIDs for Timor Leste and UAE, fix Honduras

### DIFF
--- a/mids.json
+++ b/mids.json
@@ -575,7 +575,7 @@
         "",
         "Guatemala"
     ],
-    "335": [
+    "334": [
         "HN",
         "HND",
         "",
@@ -1013,6 +1013,12 @@
         "",
         "United Arab Emirates"
     ],
+    "471": [
+        "AE",
+        "ARE",
+        "",
+        "United Arab Emirates"
+    ],
     "472": [
         "TJ",
         "TJK",
@@ -1186,6 +1192,12 @@
         "PHL",
         "",
         "Philippines"
+    ],
+    "550": [
+        "TL",
+        "TLS",
+        "",
+        "Timor-Leste (Democratic Republic of)"
     ],
     "553": [
         "PG",


### PR DESCRIPTION
Based on the [ITU data](https://www.itu.int/en/ITU-R/terrestrial/fmd/pages/mid.aspx).

Initially I just noticed that Timor-Leste was missing, then also noticed that the United Arab Emirates got an additional number (471), and I thought Honduras also got a new number, but it was actually just off-by one (Honduras has 334 instead of 335).